### PR TITLE
Field for Filename of the playground content added

### DIFF
--- a/hugo/content/_index.html
+++ b/hugo/content/_index.html
@@ -17,35 +17,35 @@ type: oct
         </div>
     </div>
 </section>
-<section class="flex justify-center items-center w-full">
+<section class="flex items-center justify-center w-full">
     <div class="flex flex-wrap justify-center gap-11 w-4/5 max-w-[1200px] mt-[75px] font-urbanist">
-        <div class="max-w-64 p-9 box-content text-richBlack bg-columbiaBlue">
+        <div class="box-content max-w-64 p-9 text-richBlack bg-columbiaBlue">
             <h2 class="text-center font-bold text-2xl leading-[normal] mb-4">Multiple cursors</h2>
             <p class="leading-[normal]">See what others are looking at: the cursors and selections of all participants are highlighted in your editor.</p>
         </div>
-        <div class="max-w-64 p-9 box-content text-richBlack bg-columbiaBlue">
+        <div class="box-content max-w-64 p-9 text-richBlack bg-columbiaBlue">
             <h2 class="text-center font-bold text-2xl leading-[normal] mb-4">End-to-end encryption</h2>
             <p class="leading-[normal]">Messages between participants are encrypted so not even the server knows what you are sharing – only those you invited do.</p>
         </div>
-        <div class="max-w-64 p-9 box-content text-richBlack bg-columbiaBlue">
+        <div class="box-content max-w-64 p-9 text-richBlack bg-columbiaBlue">
             <h2 class="text-center font-bold text-2xl leading-[normal] mb-4">IDE extensions</h2>
             <p class="leading-[normal]">Get the VS Code extension from <a href="https://open-vsx.org/extension/typefox/open-collaboration-tools" class="text-eminence hover:underline">Open VSX</a> or the <a href="https://marketplace.visualstudio.com/items?itemName=typefox.open-collaboration-tools" class="text-eminence hover:underline">VS Code Marketplace</a>. Eclipse Theia has a <a href="https://www.npmjs.com/package/@theia/collaboration" class="text-eminence hover:underline">built-in extension package</a> for the direct integration of Open Collaboration Tools.</p>
         </div>
-        <div class="max-w-64 p-9 box-content text-richBlack bg-columbiaBlue">
+        <div class="box-content max-w-64 p-9 text-richBlack bg-columbiaBlue">
             <h2 class="text-center font-bold text-2xl leading-[normal] mb-4">Integrate in your web app</h2>
             <p class="leading-[normal]">Include collaborative editing right in your web application with a text editor such as <a href="https://microsoft.github.io/monaco-editor/" class="text-eminence hover:underline">Monaco</a>. You can even share contents between the web app and an IDE!</p>
         </div>
-        <div class="max-w-64 p-9 box-content text-richBlack bg-columbiaBlue">
+        <div class="box-content max-w-64 p-9 text-richBlack bg-columbiaBlue">
             <h2 class="text-center font-bold text-2xl leading-[normal] mb-4">Customize everything</h2>
             <p class="leading-[normal]">Connect your custom editors: text-based, form-based, graphical, or any other paradigm. Empower your users with real-time collaboration, regardless of their background and expertise.</p>
         </div>
-        <div class="max-w-64 p-9 box-content text-richBlack bg-columbiaBlue">
+        <div class="box-content max-w-64 p-9 text-richBlack bg-columbiaBlue">
             <h2 class="text-center font-bold text-2xl leading-[normal] mb-4">Deploy on-premises</h2>
             <p class="leading-[normal]">You wish to adopt Open Collaboration Tools in your organization? The server is easy to deploy behind your firewall and can be connected to your authentication service.</p>
         </div>
     </div>
 </section>
-<section class="flex justify-center items-center w-full">
+<section class="flex items-center justify-center w-full pb-16">
     <div class="w-4/5 max-w-[850px] mt-[50px] font-urbanist leading-[1.35rem]">
         <hr class="flex-grow w-full h-[5px] text-eminence bg-eminence border-none">
         <h1 class="text-[2.25rem] leading-[normal] my-[0.83em] font-bold">The Public Open Collaboration Server</h1>

--- a/hugo/layouts/partials/oct-footer.html
+++ b/hugo/layouts/partials/oct-footer.html
@@ -1,12 +1,12 @@
-<footer class="w-full mt-[75px] flex justify-center items-center text-white bg-eminence font-barlow font-light">
+<footer class="flex items-center justify-center w-full font-light text-white bg-eminence font-barlow">
     <div class="flex justify-center items-center gap-4 py-4 w-4/5 max-w-[1300px]">
-        <a href="http://www.eclipse.org/legal/privacy.php" class="hover:underline text-center">Privacy Policy</a>
+        <a href="http://www.eclipse.org/legal/privacy.php" class="text-center hover:underline">Privacy Policy</a>
         <p class="my-[1em] px-2"> • </p>
-        <a href="http://www.eclipse.org/legal/termsofuse.php" class="hover:underline text-center">Terms of Use</a>
+        <a href="http://www.eclipse.org/legal/termsofuse.php" class="text-center hover:underline">Terms of Use</a>
         <p class="px-2"> • </p>
-        <a href="http://www.eclipse.org/legal/copyright.php" class="hover:underline text-center">Copyright Agent</a>
+        <a href="http://www.eclipse.org/legal/copyright.php" class="text-center hover:underline">Copyright Agent</a>
         <p class="px-2"> • </p>
-        <a href="http://www.eclipse.org/legal" class="hover:underline text-center">Legal</a>
+        <a href="http://www.eclipse.org/legal" class="text-center hover:underline">Legal</a>
         <p class="px-2"> • </p>
         <div class="text-center">
             &copy; 2025 by <a href="http://www.eclipse.org/" target="_blank" class="hover:underline">Eclipse

--- a/playground/src/components/App.tsx
+++ b/playground/src/components/App.tsx
@@ -128,15 +128,15 @@ export function App() {
       case 'loading':
         return <Spinner />;
       case 'login':
-        return <div className="w-full h-full flex justify-center items-center">
+        return <div className="flex items-center justify-center w-full h-full">
           <Login token={token} serverUrl={SERVER_URL} onLogin={handleLogin} onBack={handleBack} />
         </div>
       case 'editor':
-        return <div className="w-full flex grow min-h-[calc(100vh-110px-56px)] ">
+        return <div className="flex w-full grow">
           <MonacoEditorPage roomToken={roomToken!} collabApi={collabApi!} />
         </div>;
       case 'joinInput':
-        return <div className="w-full h-full flex justify-center items-center grow">
+        return <div className="flex items-center justify-center w-full h-full grow">
         <RoomTokenInput onToken={handleJoinToken} onBack={handleBack} />
       </div>;
       default:
@@ -144,18 +144,31 @@ export function App() {
     }
   }
 
+  const content = () => {
+    return (
+      <>
+        {renderCurrentPage()}
+        {error && <div className="p-4 text-center text-red-500">{error}</div>}
+      </>
+    )
+  }
+
+  const container = () => {
+    return (
+      <div className="flex flex-col items-center justify-center h-full font-urbanist grow">
+        {content()}
+      </div>
+    )
+  }
 
   return (
-    <div className="flex flex-col justify-center items-center h-full font-urbanist grow">
-      {renderCurrentPage()}
-      {error && <div className="text-center p-4 text-red-500">{error}</div>}
-    </div>
+    page === 'editor' ? content() : container()
   );
 }
 
 export function Spinner() {
   return (
-    <div className="flex justify-center items-center h-full">
+    <div className="flex items-center justify-center h-full">
         <div className="animate-spin rounded-full h-[64px] w-[64px] border-4 border-b-transparent border-eminence border-solid"></div>
     </div>  );
 }

--- a/playground/src/components/FileInfo.tsx
+++ b/playground/src/components/FileInfo.tsx
@@ -1,0 +1,82 @@
+// ******************************************************************************
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+// ******************************************************************************
+
+import { useEffect, useState } from 'react';
+import { MonacoCollabApi } from "open-collaboration-monaco";
+
+export type FileInfoProps = {
+  collabApi: MonacoCollabApi;
+}
+
+export const FileInfo = ({collabApi}: FileInfoProps) => {
+  const [fileName, setFileName] = useState('playground.txt');
+  const [isHost, setIsHost] = useState<boolean | undefined>();
+  const [isDirty, setIsDirty] = useState(false);
+  const [originalFileName, setOriginalFileName] = useState('playground.txt');
+
+  useEffect(() => {
+    collabApi.getUserData().then(ud => {
+        setIsHost(ud?.me.host);
+    })
+  }, [collabApi]);
+
+  const handleFileNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setFileName(newValue);
+    setIsDirty(newValue !== originalFileName);
+  };
+
+  const handleSave = () => {
+    // Dummy function for now
+    console.log('Saving file name:', fileName);
+    setOriginalFileName(fileName);
+    setIsDirty(false);
+  };
+
+  const isFileNameValid = fileName.trim().length > 0;
+
+  return (
+    <div className="flex items-center gap-2">
+      {isHost ? (
+        <>
+          <div className="relative flex-1">
+            <input
+              type="text"
+              value={fileName}
+              onChange={handleFileNameChange}
+              placeholder="Enter a file name"
+              className={`px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-eminence focus:border-transparent w-full ${
+                !isFileNameValid 
+                  ? 'border-red-500' 
+                  : isDirty 
+                    ? 'border-yellow-500' 
+                    : 'border-gray-300'
+              }`}
+            />
+            {isDirty && (
+              <div className="absolute w-2 h-2 bg-yellow-500 rounded-full -top-1 -right-1" />
+            )}
+          </div>
+          <button
+            onClick={handleSave}
+            disabled={!isFileNameValid || !isDirty}
+            className={`px-4 py-2 rounded ${
+              isFileNameValid && isDirty
+                ? 'bg-eminence text-white hover:bg-eminence-dark'
+                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+            }`}
+          >
+            Save
+          </button>
+        </>
+      ) : (
+        <div className="px-3 py-2 border border-gray-300 rounded">
+          {fileName}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/playground/src/components/FileInfo.tsx
+++ b/playground/src/components/FileInfo.tsx
@@ -12,15 +12,22 @@ export type FileInfoProps = {
 }
 
 export const FileInfo = ({collabApi}: FileInfoProps) => {
-  const [fileName, setFileName] = useState('playground.txt');
+  const [fileName, setFileName] = useState(collabApi.getFileName() ?? 'playground.txt');
   const [isHost, setIsHost] = useState<boolean | undefined>();
   const [isDirty, setIsDirty] = useState(false);
-  const [originalFileName, setOriginalFileName] = useState('playground.txt');
+  const [originalFileName, setOriginalFileName] = useState(collabApi.getFileName() ?? 'playground.txt');
+  const [roomName, setRoomName] = useState<string>(collabApi.getRoomName() ?? '');
 
   useEffect(() => {
     collabApi.getUserData().then(ud => {
         setIsHost(ud?.me.host);
     })
+    collabApi.onFileNameChange(fileName => {
+      setFileName(fileName);
+      setOriginalFileName(fileName);
+      setIsDirty(false);
+    });
+
   }, [collabApi]);
 
   const handleFileNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,8 +37,8 @@ export const FileInfo = ({collabApi}: FileInfoProps) => {
   };
 
   const handleSave = () => {
-    // Dummy function for now
     console.log('Saving file name:', fileName);
+    collabApi.setFileName(fileName);
     setOriginalFileName(fileName);
     setIsDirty(false);
   };
@@ -43,6 +50,7 @@ export const FileInfo = ({collabApi}: FileInfoProps) => {
       {isHost ? (
         <>
           <div className="relative flex-1">
+            <div className="mb-1 text-sm text-gray-500">{roomName}</div>
             <input
               type="text"
               value={fileName}
@@ -73,8 +81,11 @@ export const FileInfo = ({collabApi}: FileInfoProps) => {
           </button>
         </>
       ) : (
-        <div className="px-3 py-2 border border-gray-300 rounded">
-          {fileName}
+        <div className="flex flex-col">
+          <div className="text-sm text-gray-500">{roomName}</div>
+          <div className="px-3 py-2 border border-gray-300 rounded">
+            {fileName}
+          </div>
         </div>
       )}
     </div>

--- a/playground/src/components/MonacoEditor.tsx
+++ b/playground/src/components/MonacoEditor.tsx
@@ -23,7 +23,7 @@ export function MonacoEditor(props: MonacoEditorProps) {
     }, [props.collabApi]);
 
     return <MonacoEditorReactComp
-        className="h-full w-full grow"
+        className="w-full h-full grow"
         wrapperConfig={
             {
                 $type: 'classic',

--- a/playground/src/components/MonacoEditorPage.tsx
+++ b/playground/src/components/MonacoEditorPage.tsx
@@ -7,6 +7,7 @@
 import { MonacoCollabApi } from "open-collaboration-monaco";
 import { MonacoEditor } from "./MonacoEditor.js";
 import { RoomInfo } from "./RoomInfo.js";
+import { FileInfo } from "./FileInfo.js";
 
 export type MonacoEditorPageProps = {
   roomToken: string;
@@ -15,12 +16,17 @@ export type MonacoEditorPageProps = {
 
 export const MonacoEditorPage = (props: MonacoEditorPageProps) => {
   return (
-    <div className="flex grow">
-      <div className="flex-1 overflow-auto grow">
-        <MonacoEditor collabApi={props.collabApi} />
+    <div className="flex flex-col grow">
+      <div className="flex items-center p-4 bg-columbiaBlue">
+        <FileInfo collabApi={props.collabApi} />
       </div>
-      <div className="w-60 h-full bg-columbiaBlue p-4">
-        <RoomInfo collabApi={props.collabApi} roomToken={props.roomToken} />
+      <div className="flex grow">
+        <div className="flex-1 overflow-auto grow">
+          <MonacoEditor collabApi={props.collabApi} />
+        </div>
+        <div className="h-full p-4 w-60 bg-columbiaBlue">
+          <RoomInfo collabApi={props.collabApi} roomToken={props.roomToken} />
+        </div>
       </div>
     </div>
   )

--- a/playground/src/components/MonacoEditorPage.tsx
+++ b/playground/src/components/MonacoEditorPage.tsx
@@ -8,7 +8,7 @@ import { MonacoCollabApi } from "open-collaboration-monaco";
 import { MonacoEditor } from "./MonacoEditor.js";
 import { RoomInfo } from "./RoomInfo.js";
 import { FileInfo } from "./FileInfo.js";
-
+import { useState } from "react";
 export type MonacoEditorPageProps = {
   roomToken: string;
   collabApi: MonacoCollabApi;

--- a/playground/tailwind.config.mjs
+++ b/playground/tailwind.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('tailwindcss').Config} */
 
-const colors = require('tailwindcss/colors')
 const baseConfig = require('../tailwind/base.tailwind.config')
 
 export default {

--- a/tailwind/base.tailwind.config.js
+++ b/tailwind/base.tailwind.config.js
@@ -1,5 +1,4 @@
 /** @type {import('tailwindcss').Config} */
-const colors = require('tailwindcss/colors')
 
 module.exports = {
   mode: 'jit',


### PR DESCRIPTION
Adds input field  and handling for (file)name playground content for host. For guests it is readonly.
Plus some layout changes.

This is highly dependent of https://github.com/eclipse-oct/open-collaboration-tools/pull/133 to be published!