### PR TITLE
[Playground] Layout improvements

### DIFF
--- a/hugo/layouts/partials/oct-footer.html
+++ b/hugo/layouts/partials/oct-footer.html
@@ -6,10 +6,10 @@
         <p class="px-2"> • </p>
         <a href="https://www.eclipse.org/legal/copyright/" class="text-center hover:underline">Copyright Agent</a>
         <p class="px-2"> • </p>
-        <a href="http://www.eclipse.org/legal" class="text-center hover:underline">Legal</a>
+        <a href="https://www.eclipse.org/legal" class="text-center hover:underline">Legal</a>
         <p class="px-2"> • </p>
         <div class="text-center">
-            &copy; 2025 by <a href="http://www.eclipse.org/" target="_blank" class="hover:underline">Eclipse
+            &copy; 2025 by <a href="https://www.eclipse.org/" target="_blank" class="hover:underline">Eclipse
                 Foundation</a>
         </div>
     </div>

--- a/playground/src/components/FileInfo.tsx
+++ b/playground/src/components/FileInfo.tsx
@@ -54,51 +54,45 @@ export const FileInfo = ({collabApi, onFileNameChange}: FileInfoProps) => {
 
   const isFileNameValid = fileName.trim().length > 0;
 
-  return (
-    <div className="flex items-center gap-2">
-      {isHost ? (
-        <>
-          <div className="text-sm font-light text-columbiaBlue">
-            {roomName} &gt;
-          </div>
-          <div className="relative flex-1">
-            <div className="flex items-center gap-2">
-                <input
-                  type="text"
-                  value={fileName}
-                  onChange={handleFileNameChange}
-                  onKeyDown={handleKeyDown}
-                  placeholder="Enter a file name"
-                  className={`px-2 py-0.5 border rounded focus:outline-none focus:ring-2 focus:ring-eminence focus:border-transparent w-full ${
-                      !isFileNameValid
-                      ? 'border-red-500'
-                      : isDirty
-                          ? 'border-yellow-500'
-                          : 'border-gray-300'
-                }`}
-                />
-                <button
-                    onClick={handleSave}
-                    disabled={!isFileNameValid || !isDirty}
-                    className={`px-4 py-0.5 rounded ${
-                    isFileNameValid && isDirty
-                        ? 'bg-eminence text-white hover:bg-eminence-dark'
-                        : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                    }`}
-                >
-                    Apply
-                </button>
-            </div>
-          </div>
-        </>
-      ) : (
-        <div className="flex flex-col">
-          {/* Padding and minimum height to keep the size consistent with the host view */}
-          <div className="text-sm font-light text-columbiaBlue py-[5px] min-h-[30px]">
-            {roomName} &gt; {fileName.split('/').join(' > ')}
-          </div>
+  if (isHost) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="text-sm font-light text-columbiaBlue">
+          <span>{roomName}</span><span className='pl-2'>&#8227;</span>
         </div>
-      )}
-    </div>
-  );
+        <input
+          type="text"
+          value={fileName}
+          onChange={handleFileNameChange}
+          onKeyDown={handleKeyDown}
+          placeholder="Enter a file name"
+          className={`px-2 py-0.5 border rounded focus:outline-none focus:ring-2 focus:ring-eminence focus:border-transparent w-full ${
+              !isFileNameValid
+              ? 'border-red-500'
+              : isDirty
+                ? 'border-yellow-500'
+                : 'border-gray-300'
+          }`}
+        />
+        <button
+            onClick={handleSave}
+            disabled={!isFileNameValid || !isDirty}
+            className={`px-4 py-0.5 rounded ${
+            isFileNameValid && isDirty
+                ? 'bg-eminence text-white hover:bg-eminence-dark'
+                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+            }`}
+        >
+            Apply
+        </button>
+      </div>
+    );
+  } else {
+    return (
+        <div className="text-sm font-light text-columbiaBlue py-[5px]">
+          <span>{roomName}</span>
+          {fileName.split('/').flatMap(p => [<span className='px-2'>&#8227;</span>, <span>{p}</span>])}
+        </div>
+    );
+  }
 };

--- a/playground/src/components/MonacoEditorPage.tsx
+++ b/playground/src/components/MonacoEditorPage.tsx
@@ -7,7 +7,7 @@
 import { MonacoCollabApi } from "open-collaboration-monaco";
 import { RoomInfo } from "./RoomInfo.js";
 import { FileInfo } from "./FileInfo.js";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 import { MonacoEditorReactComp } from "@typefox/monaco-editor-react";
 import { MonacoEditorLanguageClientWrapper } from "monaco-editor-wrapper";
 import '@codingame/monaco-vscode-standalone-languages';
@@ -66,14 +66,15 @@ export const MonacoEditorPage = (props: MonacoEditorPageProps) => {
                 <FontAwesomeIcon icon={faArrowRightFromBracket} className="cursor-pointer size-6" color="white" onClick={handleLeaveRoom} title="Leave session" />
             </div>
             <div className="flex grow">
-                <div className="flex-1 overflow-auto grow">
+                <div className="flex-1 relative">
                     <MonacoEditorReactComp
-                        className="w-full h-full grow"
+                        className="absolute inset-0"
                         wrapperConfig={
                             {
                                 $type: 'classic',
                                 editorAppConfig: {
                                     editorOptions: {
+                                        automaticLayout: true,
                                         language: 'plaintext',
                                         value: ''
                                     }
@@ -81,7 +82,7 @@ export const MonacoEditorPage = (props: MonacoEditorPageProps) => {
                             }
                         } onLoad={handleOnLoad} />
                 </div>
-                <div className="h-full p-4 w-60 bg-columbiaBlue">
+                <div className="h-full p-4 bg-columbiaBlue">
                     <RoomInfo collabApi={props.collabApi} roomToken={props.roomToken} />
                 </div>
             </div>

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -41,16 +41,16 @@ root.render(
     </main>
     <footer className="w-full h-[60px] flex items-center justify-center font-light text-white bg-eminence font-barlow text-xs md:text-base">
         <div className="flex justify-center items-center gap-3 md:gap-4 py-2 w-[90%] max-w-[1300px]">
-            <a href="http://www.eclipse.org/legal/privacy.php" className="text-center hover:underline">Privacy Policy</a>
+            <a href="https://www.eclipse.org/legal/privacy/" className="text-center hover:underline">Privacy Policy</a>
             <p className="md:px-2"> • </p>
-            <a href="http://www.eclipse.org/legal/termsofuse.php" className="text-center hover:underline">Terms of Use</a>
+            <a href="https://www.eclipse.org/legal/terms-of-use/" className="text-center hover:underline">Terms of Use</a>
             <p className="md:px-2"> • </p>
-            <a href="http://www.eclipse.org/legal/copyright.php" className="text-center hover:underline">Copyright Agent</a>
+            <a href="https://www.eclipse.org/legal/copyright/" className="text-center hover:underline">Copyright Agent</a>
             <p className="md:px-2"> • </p>
-            <a href="http://www.eclipse.org/legal" className="text-center hover:underline">Legal</a>
+            <a href="https://www.eclipse.org/legal" className="text-center hover:underline">Legal</a>
             <p className="md:px-2"> • </p>
             <div className="text-center">
-                &copy; 2025 by <a href="http://www.eclipse.org/" target="_blank" className="hover:underline">Eclipse
+                &copy; 2025 by <a href="https://www.eclipse.org/" target="_blank" className="hover:underline">Eclipse
                     Foundation</a>
             </div>
         </div>


### PR DESCRIPTION
This change makes the Monaco editor size adaptable to its container so it's auto-resized.

I also simplified the FileInfo component structure and used a triangular bullet (‣) instead of a `>` as path separator.