### PR TITLE
New open-collaboration-monaco version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4162,6 +4162,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -4258,9 +4259,10 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.108",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.108.tgz",
-      "integrity": "sha512-+3eK/B0SqYoZiQu9fNk4VEc6EX8cb0Li96tPGKgugzoGj/OdRdREtuTLvUW+mtinoB2mFiJjSqOJBIaMkAGhxQ==",
+      "version": "0.2.109",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.109.tgz",
+      "integrity": "sha512-jP0gbnyW0kwlx1Atc4dcHkBbrVAkdHjuyHxtClUPYla7qCmwIif1qZ6vQeJdR5FrOVdn26HvQT0ko01rgW7/Xw==",
+      "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -4720,21 +4722,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/open-collaboration-monaco": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/open-collaboration-monaco/-/open-collaboration-monaco-0.3.2.tgz",
-      "integrity": "sha512-yOJoxPEwimche+vW6QDOquV0FL5WJUl7+R3VE5NGdIrXQrmBUqxwGDcnhbJ45UsD+tTQ09kWwieuN4tYDt8fqg==",
-      "dependencies": {
-        "lodash": "~4.17.21",
-        "monaco-editor": "~0.52.2",
-        "open-collaboration-protocol": "~0.3.1",
-        "open-collaboration-yjs": "~0.3.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/open-collaboration-protocol": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/open-collaboration-protocol/-/open-collaboration-protocol-0.3.1.tgz",
@@ -4763,13 +4750,13 @@
       }
     },
     "node_modules/open-collaboration-yjs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/open-collaboration-yjs/-/open-collaboration-yjs-0.3.0.tgz",
-      "integrity": "sha512-XQk8ywZO5JiQo1QlRWcqR3C9RvEUuWi5FSDooIVqe/jZy9RMwQZs5ywz0a5cP8XQ7sTDhh6WjPwtG67laUP6uw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/open-collaboration-yjs/-/open-collaboration-yjs-0.3.1.tgz",
+      "integrity": "sha512-sMs2YBntYaWW3ck8msiINZOED80wGQWzuX2uBOqPMWDv0qmKHYsgSNpJ1cAvcYIeM/2pfxRC53ihpKlSW38HdQ==",
+      "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.103",
         "open-collaboration-protocol": "~0.3.0",
-        "vscode-languageserver-textdocument": "~1.0.12",
         "y-protocols": "~1.0.6"
       },
       "engines": {
@@ -6223,11 +6210,6 @@
         "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
-    },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
@@ -6414,6 +6396,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
       "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -6460,6 +6443,7 @@
       "version": "13.6.27",
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
       "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
@@ -6493,9 +6477,28 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@typefox/monaco-editor-react": "6.8.0",
         "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~17.1.2",
-        "open-collaboration-monaco": "^0.3.2",
+        "open-collaboration-monaco": "^0.3.3",
+        "open-collaboration-yjs": "^0.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "playground/node_modules/open-collaboration-monaco": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/open-collaboration-monaco/-/open-collaboration-monaco-0.3.3.tgz",
+      "integrity": "sha512-IH23K+Yv7LJoxwS98fiW0WaPXZj9IJP5rV4R5f8wutPu3rYm+KAYsdSg3VZjt5UyBNS0a3elFZZWquuOA8VkzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "~4.17.21",
+        "open-collaboration-protocol": "~0.3.1",
+        "open-collaboration-yjs": "~0.3.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.44.0"
       }
     },
     "tailwind": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -23,7 +23,8 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@typefox/monaco-editor-react": "6.8.0",
     "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~17.1.2",
-    "open-collaboration-monaco": "^0.3.2",
+    "open-collaboration-monaco": "^0.3.3",
+    "open-collaboration-yjs": "^0.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
Using open-collaboration-monaco 0.3.3 now.
Adding open-collaboration-yjs 0.3.1 directly here as it wasn't pulled via monaco pkg.