### PR TITLE
Improved errors for joining and creating rooms

### DIFF
--- a/playground/src/components/App.tsx
+++ b/playground/src/components/App.tsx
@@ -13,7 +13,7 @@ import { StartButtons } from "./StartButtons.js";
 import { RoomTokenInput } from "./RoomTokenInput.js";
 import { MonacoEditorPage } from "./MonacoEditorPage.js";
 
-const SERVER_URL = 'http://localhost:8100';
+const SERVER_URL = 'https://api.open-collab.tools';
 
 type pages = 'login' | 'editor' | 'startButtons' | 'joinInput' | 'loading';
 


### PR DESCRIPTION
Error messages from monaco-api now dispayed correctly.

Be aware the timeout error has some issus on oct-monaco side and there is a [missing spacebar](https://github.com/eclipse-oct/open-collaboration-tools/pull/148) in the join errors