### PR TITLE
monaco editor worker is properly configured in the playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6477,6 +6477,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@typefox/monaco-editor-react": "6.8.0",
         "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~17.1.2",
+        "monaco-languageclient": "9.7.0",
         "open-collaboration-monaco": "^0.3.3",
         "open-collaboration-yjs": "^0.3.1",
         "react": "^18.3.1",

--- a/playground/esbuild.mjs
+++ b/playground/esbuild.mjs
@@ -1,23 +1,38 @@
 //@ts-check
 import * as esbuild from 'esbuild';
 
-const ctx = await esbuild.context({
-    entryPoints: ['src/index.tsx'],
-    outdir: 'dist/assets',
-    bundle: true,
-    target: "ESNext",
-    format: 'esm',
-    loader: {
-        '.svg': 'file',
-        '.png': 'file',
-        '.ttf': 'file'
-    },
-    external: ['/assets/header-background.webp'],
-    platform: 'browser',
-    sourcemap: false,
-    minify: true,
-    logLevel: 'info'
-});
+const bundleWorker = async () => {
+    await esbuild.build({
+        entryPoints: ['../node_modules/monaco-editor/esm/vs/editor/editor.worker.js'],
+        bundle: true,
+        treeShaking: true,
+        minify: true,
+        format: 'esm',
+        allowOverwrite: true,
+        logLevel: 'info',
+        outfile: './dist/assets/editor.worker.js'
+    });
+};
 
-await ctx.rebuild();
-ctx.dispose();
+const bundlePlayground = async () => {
+    await esbuild.build({
+        entryPoints: ['src/index.tsx'],
+        outdir: 'dist/assets',
+        bundle: true,
+        target: "ESNext",
+        format: 'esm',
+        loader: {
+            '.svg': 'file',
+            '.png': 'file',
+            '.ttf': 'file'
+        },
+        external: ['/assets/header-background.webp'],
+        platform: 'browser',
+        sourcemap: false,
+        minify: true,
+        logLevel: 'info'
+    });
+};
+
+await bundlePlayground();
+await bundleWorker();

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,6 +22,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@typefox/monaco-editor-react": "6.8.0",
+    "monaco-languageclient": "9.7.0",
     "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~17.1.2",
     "open-collaboration-monaco": "^0.3.3",
     "open-collaboration-yjs": "^0.3.1",

--- a/playground/src/components/MonacoEditorPage.tsx
+++ b/playground/src/components/MonacoEditorPage.tsx
@@ -8,6 +8,7 @@ import { MonacoCollabApi } from "open-collaboration-monaco";
 import { RoomInfo } from "./RoomInfo.js";
 import { FileInfo } from "./FileInfo.js";
 import { useCallback, useRef } from "react";
+import { useWorkerFactory } from 'monaco-languageclient/workerFactory';
 import { MonacoEditorReactComp } from "@typefox/monaco-editor-react";
 import { MonacoEditorLanguageClientWrapper } from "monaco-editor-wrapper";
 import '@codingame/monaco-vscode-standalone-languages';
@@ -77,6 +78,14 @@ export const MonacoEditorPage = (props: MonacoEditorPageProps) => {
                                         automaticLayout: true,
                                         language: 'plaintext',
                                         value: ''
+                                    },
+                                    monacoWorkerFactory: () => {
+                                        useWorkerFactory({
+                                            workerLoaders: {
+                                                // the editor worker is pre-bundled with esbuild
+                                                TextEditorWorker: () => new Worker('/playground/editor.worker.js', { type: 'module' })
+                                            }
+                                        });
                                     }
                                 }
                             }


### PR DESCRIPTION
The esbuild script is updated. It also pre-bundles the editor worker, so hugo is able to load it.